### PR TITLE
メニューの最後に不要なマージンが残っていたので削除

### DIFF
--- a/Classes/CAPSPageMenu.swift
+++ b/Classes/CAPSPageMenu.swift
@@ -377,7 +377,7 @@ public class CAPSPageMenu: UIViewController, UIScrollViewDelegate, UIGestureReco
         
         // Set new content size for menu scroll view if needed
         if menuItemWidthBasedOnTitleTextWidth {
-            menuScrollView.contentSize = CGSizeMake((totalMenuItemWidthIfDifferentWidths + menuMargin) + CGFloat(controllerArray.count) * menuMargin, menuHeight)
+            menuScrollView.contentSize = CGSizeMake(totalMenuItemWidthIfDifferentWidths + CGFloat(controllerArray.count) * menuMargin, menuHeight)
         }
         
         // Set selected color for title label of selected menu item


### PR DESCRIPTION
メニューの最後に menuMargin のサイズ分のマージンができていて不自然だったので削除しました。